### PR TITLE
Update Project Format and Address Ambiguity

### DIFF
--- a/Manifest.toml
+++ b/Manifest.toml
@@ -1,0 +1,21 @@
+# This file is machine-generated - editing it directly is not advised
+
+[[Base64]]
+uuid = "2a0f44e3-6c83-55bd-87e4-b1978d98bd5f"
+
+[[MacroTools]]
+deps = ["Markdown", "Random"]
+git-tree-sha1 = "6a8a2a625ab0dea913aba95c11370589e0239ff0"
+uuid = "1914dd2f-81c6-5fcd-8719-6d5c9610ff09"
+version = "0.5.6"
+
+[[Markdown]]
+deps = ["Base64"]
+uuid = "d6f4376e-aef5-505a-96c1-9c027394607a"
+
+[[Random]]
+deps = ["Serialization"]
+uuid = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
+
+[[Serialization]]
+uuid = "9e88b42a-f829-5b0c-bbe9-9e923198166b"

--- a/Project.toml
+++ b/Project.toml
@@ -1,0 +1,17 @@
+name = "Unrolled"
+uuid = "9602ed7d-8fef-5bc8-8597-8f21381861e8"
+
+[deps]
+MacroTools = "1914dd2f-81c6-5fcd-8719-6d5c9610ff09"
+
+[compat]
+julia = "≥ 0.7.0"
+
+[extras]
+MacroTools = "1914dd2f-81c6-5fcd-8719-6d5c9610ff09"
+QuickTypes = "ae2dfa86-617c-530c-b392-ef20fdad97bb"
+StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
+Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+
+[targets]
+test = ["StaticArrays", "Test", "QuickTypes", "MacroTools"]

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,2 +1,0 @@
-julia 0.7
-MacroTools

--- a/src/Unrolled.jl
+++ b/src/Unrolled.jl
@@ -118,7 +118,7 @@ macro unroll(fundef)
     # loops with macros that will perform the actual unrolling (we use intermediate macros
     # for sanity)
     expansion = postwalk(process, body)
-    exp_fun = Symbol(fname, :_unrolled_expansion_)
+    exp_fun = Symbol(gensym(), :_unrolled_expansion_) # make a new name to avoid ambiguity between expansions
     return esc(quote
         # The expansion function (for easy calling)
         Base.@__doc__ function $exp_fun($(all_args...))

--- a/src/Unrolled.jl
+++ b/src/Unrolled.jl
@@ -118,7 +118,7 @@ macro unroll(fundef)
     # loops with macros that will perform the actual unrolling (we use intermediate macros
     # for sanity)
     expansion = postwalk(process, body)
-    exp_fun = Symbol(gensym(), :_unrolled_expansion_) # make a new name to avoid ambiguity between expansions
+    exp_fun = Symbol(fname, :_unrolled_expansion_, gensym()) # gensym to support multiple methods
     return esc(quote
         # The expansion function (for easy calling)
         Base.@__doc__ function $exp_fun($(all_args...))

--- a/test/REQUIRE
+++ b/test/REQUIRE
@@ -1,3 +1,0 @@
-StaticArrays
-MacroTools
-QuickTypes


### PR DESCRIPTION
This does two things:

* Functional update: originally, Unrolled.jl would generate a method named [original function name]\_unrolled\_expansion\_ that would contain the generated method body. However, this creates issues when there are multiple methods with the same name and different type signatures that are all unrolled, as all of them will have the same unrolled expansion. Here, instead of using the original function name, we use a fresh symbol to avoid a clash.
* It updates the project to use the new Project.toml format. This is still slightly out of date, as the way that the test deps are registered isn't up to date, but it's supported through 1.x at least.